### PR TITLE
cloud-function.py をリファクタリング

### DIFF
--- a/cloud-function.py
+++ b/cloud-function.py
@@ -9,7 +9,7 @@ from sudachipy import tokenizer, dictionary
 
 POSTPOSITONAL_PARTICLE = '助詞'
 
-def hello_world(request):
+def calc_meigen_for_schedule(request):
 
     request_json = request.get_json()
     if request_json and 'schedule' in request_json and 'plan' in request_json:

--- a/cloud-function.py
+++ b/cloud-function.py
@@ -7,46 +7,84 @@ from pymagnitude import Magnitude
 from sudachipy import tokenizer, dictionary
 
 
-POSTPOSITONAL_PARTICLE = "助詞"
+POSTPOSITONAL_PARTICLE = '助詞'
 
 def hello_world(request):
 
     request_json = request.get_json()
-    if request.args and 'message' in request.args:
-        return request.args.get('message')
-    elif request_json and 'message' in request_json:
-        return request_json['message']
-    else:
-
+    if request_json and 'schedule' in request_json and 'plan' in request_json:
         model, meigen_vecs, meigen_list = load_tools()
-        tokenizer_obj = dictionary.Dictionary().create()
         schedule = request_json['schedule']
         plan = request_json['plan']
 
         schedule_with_similar_words = schedule
-        if plan == "premium":
-          schedule_with_similar_words = generate_schedule_with_similar_words(model, tokenizer_obj, schedule)
+        if plan == 'premium':
+          schedule_with_similar_words = generate_schedule_with_similar_words(model, schedule)
         
-        schedule_vec = word2vector(model, tokenizer_obj, schedule_with_similar_words)
+        schedule_vec = calc_schedule_vec(model, schedule_with_similar_words)
 
-        if schedule_vec is not None:
-          max_similarity_score = 0
-          max_index = 0
-          for i, vec_key in enumerate(meigen_vecs.files):
-            meigen_vec = meigen_vecs[vec_key]
-            if max_similarity_score < cos_similarity(schedule_vec, meigen_vec.T):
-              max_similarity_score = cos_similarity(schedule_vec, meigen_vec.T)
-              max_index = i
-        else:
-          max_index = 0
-            
-        most_fit_meigen = ((meigen_list["Sheet1"]).cell(int(max_index)+1, 2)).value
+        most_fit_meigen = calc_most_fit_meigen(schedule_vec, meigen_vecs, meigen_list)
         
-        return json.dumps({"most_fit_meigen": most_fit_meigen}, ensure_ascii=False)
+        return json.dumps({'most_fit_meigen': most_fit_meigen}, ensure_ascii=False)
+    else:
+      return 'nothing'
 
-def word2vector(model, tokenizer_obj, sentence, unknowns=[]):
 
+def load_tools():
+    storage_client = storage.Client()
+    bucket = storage_client.get_bucket('gcf-sources-1048067232771-us-central1')
+
+    word2_vec_model = load_word2_vec_model(bucket)
+    meigen_vecs = load_meigen_vecs(bucket)
+    meige_list = load_meigen_list(bucket)
+
+    return model, meigen_vecs, meigen_list
+
+def load_meigen_vecs(bucket):
+  blob = bucket.get_blob('meigen_vecs_chiVe.npz')
+  blob.download_to_filename('/tmp/meigen_vecs_chiVe.npz')
+  meigen_vecs = np.load('/tmp/meigen_vecs_chiVe.npz')
+
+  return meigen_vecs
+
+def load_meigen_list(bucket):
+  blob = bucket.get_blob('meigen_list.xlsx')
+  blob.download_to_filename('/tmp/meigen_list.xlsx')
+  meigen_list = openpyxl.load_workbook('/tmp/meigen_list.xlsx')
+
+  return meigen_list
+
+def load_word2_vec_model(bucket):
+  blob = bucket.get_blob('chive-1.2-mc90.magnitude')
+  blob.download_to_filename('/tmp/chive-1.2-mc90.magnitude')
+  word2_vec_model = Magnitude('/tmp/chive-1.2-mc90.magnitude')
+
+  return word2_vec_model
+
+def generate_schedule_with_similar_words(model, schedule):
+
+  tokenizer_obj = dictionary.Dictionary().create()
+  ms = tokenizer_obj.tokenize(schedule)
+
+  schedule_with_similar_words = schedule
+
+  for m in ms:
+    if m.part_of_speech()[0] != POSTPOSITONAL_PARTICLE:
+        w = m.surface()
+        try:
+          for sm in model.most_similar(w, topn=4):
+            schedule_with_similar_words += sm[0]
+        except KeyError as e:
+          print(e)
+
+  return schedule_with_similar_words
+
+
+def calc_schedule_vec(model, sentence, unknowns=[]):
+
+    tokenizer_obj = dictionary.Dictionary().create()
     ms = tokenizer_obj.tokenize(sentence)
+
     _sv = np.empty((0,300), np.float32)
     for m in ms:
       if not m.part_of_speech()[0].endswith(POSTPOSITONAL_PARTICLE):
@@ -66,40 +104,19 @@ def word2vector(model, tokenizer_obj, sentence, unknowns=[]):
 def cos_similarity(v1, v2):
     return np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
 
+def calc_most_fit_meigen(schedule_vec, meigen_vecs, meigen_list):
 
-def load_tools():
-    storage_client = storage.Client()
-    bucket = storage_client.get_bucket('gcf-sources-1048067232771-us-central1')
-
-    blob = bucket.get_blob('chive-1.2-mc90.magnitude')
-    blob.download_to_filename("/tmp/chive-1.2-mc90.magnitude")
+  if schedule_vec is not None:
+    max_similarity_score = 0
+    max_index = 0
+    for i, vec_key in enumerate(meigen_vecs.files):
+      meigen_vec = meigen_vecs[vec_key]
+      if max_similarity_score < cos_similarity(schedule_vec, meigen_vec.T):
+        max_similarity_score = cos_similarity(schedule_vec, meigen_vec.T)
+        max_index = i
+  else:
+    max_index = 0
   
-    blob = bucket.get_blob('meigen_list.xlsx')
-    blob.download_to_filename("/tmp/meigen_list.xlsx")
+  most_fit_meigen = ((meigen_list['Sheet1']).cell(int(max_index)+1, 2)).value
 
-    blob = bucket.get_blob('meigen_vecs_chiVe.npz')
-    blob.download_to_filename("/tmp/meigen_vecs_chiVe.npz")
-
-    model = Magnitude("/tmp/chive-1.2-mc90.magnitude")
-    meigen_vecs = np.load("/tmp/meigen_vecs_chiVe.npz")
-    meigen_list = openpyxl.load_workbook("/tmp/meigen_list.xlsx")
-
-    return model, meigen_vecs, meigen_list
-
-def generate_schedule_with_similar_words(model, tokenizer_obj, schedule):
-  
-  schedule_with_similar_words = schedule
-  ms = tokenizer_obj.tokenize(schedule)
-
-  for m in ms:
-    if m.part_of_speech()[0] != POSTPOSITONAL_PARTICLE:
-        w = m.surface()
-        if w == 'word ''':
-          continue
-        try:
-          for sm in model.most_similar(w, topn=4):
-            schedule_with_similar_words  += sm[0]
-        except KeyError as e:
-          print(e)
-
-  return schedule_with_similar_words
+  return most_fit_meigen


### PR DESCRIPTION
- load_tools を，load_meigen_vecs，load_meigen_list，load_word2_vec_model に分解
時間的凝集を小さくするため．
- 'schedule', 'plan' が request_json に含まれている場合のみ実行するようにした．
- schedule_vec との cos_similarity が最も高くなるような meigen を求める処理をcalc_most_fit_meigenに切り出した
- 使われる順に関数を並べた
- hello_worldからcalc_meigen_for_scheduleに名前を変更
